### PR TITLE
fix: flush socket on `client.puts`

### DIFF
--- a/src/crirc/network/client.cr
+++ b/src/crirc/network/client.cr
@@ -63,6 +63,7 @@ class Crirc::Network::Client
   # Send a message to the server
   def puts(data)
     socket.puts data.strip # TODO: add \r\n
+    socket.flush
   end
 
   # End the connection

--- a/src/crirc/network/client.cr
+++ b/src/crirc/network/client.cr
@@ -62,7 +62,8 @@ class Crirc::Network::Client
 
   # Send a message to the server
   def puts(data)
-    socket.puts data.strip # TODO: add \r\n
+    socket.puts data.strip
+    socket.puts "\r\n"
     socket.flush
   end
 


### PR DESCRIPTION
with `ssl: true` the messages may be bufferized, causing the server to
drop the connection after a little while (tested both on freenode and
mozilla).