### PR TITLE
update to crystal 0.34.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.5.0
 authors:
   - Arthur Poulet <arthur.poulet@sceptique.eu>
 
-crystal: 0.31.1
+crystal: 0.34.0
 
 license: MIT

--- a/src/crirc/protocol/chan.cr
+++ b/src/crirc/protocol/chan.cr
@@ -8,11 +8,11 @@ class Crirc::Protocol::Chan < Crirc::Protocol::Target
     getter timestamp : Int64
 
     def initialize(@message, @user)
-      @timestamp = Time.now.to_unix
+      @timestamp = Time.utc.to_unix
     end
 
     def set_motd(@message, @user)
-      @timestamp = Time.now.to_unix
+      @timestamp = Time.utc.to_unix
     end
   end
 


### PR DESCRIPTION
`Time.now` has been removed since `0.33.0`.