### PR TITLE
Fix dependency name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this to your application's `shard.yml`:
 
 ```yaml
 dependencies:
-  Crirc:
+  crirc:
     github: Meoowww/Crirc
 ```
 


### PR DESCRIPTION
Shard names are case-sensitive, so the snippet doesn't work with uppercase letter.